### PR TITLE
Add Performance API groups

### DIFF
--- a/web-platform-features/deprecated-performance-apis.json
+++ b/web-platform-features/deprecated-performance-apis.json
@@ -1,0 +1,28 @@
+{
+  "identifier": "deprecated-performance-apis",
+  "shortName": "Deprecated Performance APIs",
+  "longName": "Deprecated Web Performance Measurement APIs",
+  "description": "Deprecated Performance APIs that shouldn't be used anymore.",
+  "constituentFeatures": [
+    {
+      "source": "bcd",
+      "query": "api.PerformanceNavigation"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.Performance.memory"
+    },
+    {
+      "source": "bcd",
+      "query": "api.Performance.navigation"
+    },
+    {
+      "source": "bcd",
+      "query": "api.Performance.timing"
+    }
+  ]
+}

--- a/web-platform-features/performance-apis.json
+++ b/web-platform-features/performance-apis.json
@@ -1,0 +1,104 @@
+{
+  "identifier": "performance-apis",
+  "shortName": "Performance APIs",
+  "longName": "Web Performance Measurement APIs",
+  "description": "The Performance API is a group of standards used to measure the performance of web applications.",
+  "constituentFeatures": [
+    {
+      "source": "bcd",
+      "query": "api.EventCounts"
+    },
+    {
+      "source": "bcd",
+      "query": "api.LargestContentfulPaint"
+    },
+    {
+      "source": "bcd",
+      "query": "api.LayoutShift"
+    },
+    {
+      "source": "bcd",
+      "query": "api.LayoutShiftAttribution"
+    },
+    {
+      "source": "bcd",
+      "query": "api.Performance"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceEntry"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceElementTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceEventTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceLongTaskTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceMark"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceMeasure"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceNavigation"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceNavigationTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceObserver"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceObserverEntryList"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformancePaintTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceResourceTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceServerTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.PerformanceTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.TaskAttributionTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "api.performance"
+    },
+    {
+      "source": "bcd",
+      "query": "api.Element.elementTiming"
+    },
+    {
+      "source": "bcd",
+      "query": "http.headers.Server-Timing"
+    },
+    {
+      "source": "bcd",
+      "query": "http.headers.Timing-Allow-Origin"
+    }
+  ]
+}


### PR DESCRIPTION
Hey @ddbeck, here is my 30 minutes exercise to create groups for the Performance API docs that Open Web Docs is working on right now. 

I don't know if a group can be subtracted from other groups but if you would want relevant Performance APIs, it would be "performance-apis" minus "deprecated-performance-apis". 

Of course, more groups are possible here. I'd love to know what would be `performance-apis.2022.json`. Would I check what is supported in all 3 engines as of today and create a group from that?